### PR TITLE
feat: Better support for personal applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ inventories/*
 # Personal roles
 roles/personal/*
 !roles/personal/README.md
+personal_playbook.yml
 
 # Breaking change detection
 state/*

--- a/personal_playbook.yml
+++ b/personal_playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Personal Applications
+  hosts: all
+  # roles:
+    # - role: personal/my_personal_application
+    #   tags: my_personal_application
+    #   when: my_personal_application_enabled or (my_personal_application_container_names | intersect(running_containers) | length > 0)

--- a/playbook.yml
+++ b/playbook.yml
@@ -503,4 +503,7 @@
       tags: woodpecker_ci
       when: woodpecker_ci_enabled or (woodpecker_ci_container_names | intersect(running_containers) | length > 0)
 
-    # Personal Applications (in personal/ folder)
+# Personal Applications (in personal/ folder)
+- name: Execute Personal Applications
+  ansible.builtin.import_playbook: personal_playbook.yml
+  tags: ansible_run_tags

--- a/roles/personal/README.md
+++ b/roles/personal/README.md
@@ -4,4 +4,8 @@ All contents in this folder are gitignored (except this README file), are ignore
 This folder is intended to hold personal roles that are not meant to be shared with others for whatever reason.
 This could be because they are private applications, or because they are experimental and not ready for sharing yet.
 
+When adding a personal application, make sure to update the `personal_playbook.yml` file in the root of the repository, and run `git update-index --skip-worktree personal_playbook.yml` to tell git not to track changes to keep a clean environment.
+
+You can use `git update-index --no-skip-worktree personal_playbook.yml` to undo this.
+
 Remember if you have created a role that you think would be useful to others, consider sharing it with the community and creating a pull request! Contributions are always welcome.


### PR DESCRIPTION
<!--  Thank you for your contribution!

Some things to keep in mind:

1. Make sure to read through the contributing guide: https://dylancyclone.github.io/ansible-homelab-orchestration/guides/contributing/
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**: Up until now personal applications had to be added to the main `playbook.yml`, causing a dirty environment and careful staging any time you add a new application that will be committed. With this PR, personal applications are moved to a new playbook that can be untracked to preserve a clean environment (no unstaged changes with personal applications)

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:

I want to see if tests run in CI since my IDE gives some warnings but everything seems to work
