### PR TITLE
fix(prometheus): Enable remote-write receiver so Alloy metrics are accepted

### DIFF
--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -37,7 +37,8 @@
         restart_policy: unless-stopped
         restart: "{{ prometheus_config is changed }}"
         command: "--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.retention.size={{ prometheus_retention_size }} \
-          --storage.tsdb.retention.time={{ prometheus_retention_time }}"
+          --storage.tsdb.retention.time={{ prometheus_retention_time }} \
+          --web.enable-remote-write-receiver"
         memory: "{{ prometheus_memory }}"
         labels:
           traefik.enable: "{{ (prometheus_dns_accessible or prometheus_available_externally) | string }}"


### PR DESCRIPTION
## What
Adds `--web.enable-remote-write-receiver` to the Prometheus container command.

## Why
Alloy's `prometheus.remote_write` pushes scraped metrics to Prometheus at `/api/v1/write`, but Prometheus rejected them with **HTTP 404** because the remote-write receiver was not enabled. This silently dropped ~1,300 samples per push, so a chunk of metrics were never stored.

## Testing
- `python tests/test.py` passes.
- Verified on a live host: the Alloy `non-recoverable error ... 404` log entries stop and Alloy-pushed `node_*` metrics appear in Prometheus.
