### PR TITLE
fix(telegraf): Re-render config on every run; fix hddtemp and TeamSpeak inputs

### DIFF
--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -19,7 +19,7 @@
       ansible.builtin.template:
         src: telegraf.conf.j2
         dest: "{{ telegraf_config_directory }}/telegraf.conf"
-        force: false
+        force: true
       register: telegraf_config
 
     - name: Get Docker daemon uid

--- a/roles/telegraf/templates/telegraf.conf.j2
+++ b/roles/telegraf/templates/telegraf.conf.j2
@@ -6042,6 +6042,7 @@
 
 
 # # Monitor disks' temperatures using hddtemp
+{% if prometheus_hddtemp_enabled %}
 [[inputs.hddtemp]]
   ## By default, telegraf gathers temps data from all disks detected by the
   ## hddtemp.
@@ -6050,8 +6051,11 @@
   ##
   ## A * as the device name will return the temperature values of all disks.
   ##
-  # address = "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ prometheus_hddtemp_port }}"
+  ## The hddtemp daemon runs as a separate container (prometheus_hddtemp role),
+  ## so point at the host's published port rather than telegraf's own loopback.
+  address = "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ prometheus_hddtemp_port }}"
   # devices = ["sda", "*"]
+{% endif %}
 
 
 # # HTTP/HTTPS request given an address a method and a timeout

--- a/roles/telegraf/templates/telegraf.conf.j2
+++ b/roles/telegraf/templates/telegraf.conf.j2
@@ -9126,7 +9126,7 @@
 
 
 # # Reads metrics from a Teamspeak 3 Server via ServerQuery
-{% if teamspeak3_enabled %}
+{% if teamspeak3_enabled and telegraf_teamspeak3_serverquery_username is defined and telegraf_teamspeak3_serverquery_password is defined %}
 [[inputs.teamspeak]]
   ## Server address for Teamspeak 3 ServerQuery
   # server = "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ teamspeak3_port }}:{{ teamspeak3_serverquery_port }}"


### PR DESCRIPTION
Three independent telegraf fixes:

### 1. `force: true` so config changes actually deploy
The telegraf.conf template task used `force: false`, so Ansible only wrote the config the first time it was created and never overwrote it afterward. Every later template/variable change was rendered but silently **not deployed** to hosts that already had the file, and the container never restarted (its `restart` is keyed off the template changing). Set `force: true` (still idempotent — only rewrites when the rendered content differs).

### 2. hddtemp input pointed at the wrong host
The input was always enabled but left `address` commented, so it defaulted to `127.0.0.1:7634`. Inside the telegraf container that loopback has no daemon, so every collection failed with `connect: connection refused`. The hddtemp daemon actually runs as the separate `prometheus_hddtemp` container; point `address` at the host's published port and gate the input on `prometheus_hddtemp_enabled`.

### 3. TeamSpeak input crashed the render when creds were unset
The input was gated only on `teamspeak3_enabled`, but references `telegraf_teamspeak3_serverquery_username`/`_password`, which have no default. Enabling the TS3 server without setting the (documented) credentials failed the whole telegraf.conf render with an undefined-variable error. Also gate the input on those credentials being defined, matching the documented setup.

## Testing
- `python tests/test.py` passes.
- Verified on a live host: config now redeploys and restarts telegraf; hddtemp metrics flow with correct temps; the TeamSpeak block is cleanly skipped when creds are unset.
