### PR TITLE
feat(prometheus_smartctl)!: Switch to the maintained prometheus-community smartctl_exporter

### DIFF
--- a/docs/src/content/docs/applications/prometheus_smartctl.mdx
+++ b/docs/src/content/docs/applications/prometheus_smartctl.mdx
@@ -7,7 +7,7 @@ import { Aside } from "@astrojs/starlight/components"
 import Tags from "../../../components/Tags.astro"
 import RecentChanges from "../../../components/RecentChanges.astro"
 
-[Repository](https://github.com/matusnovak/prometheus-smartctl)
+[Repository](https://github.com/prometheus-community/smartctl_exporter)
 
 <Tags tags={frontmatter.tags} />
 
@@ -16,7 +16,7 @@ import RecentChanges from "../../../components/RecentChanges.astro"
   On it's own, it won't do anything
 </Aside>
 
-HDD S.M.A.R.T exporter for Prometheus written in Python
+S.M.A.R.T. metrics exporter for Prometheus, using `smartctl` to report on HDD, SSD, and NVMe devices.
 
 ## Setting up
 
@@ -31,11 +31,26 @@ By default, Prometheus smartctl can be accessed at `http://[your_server_ip]:9902
 See the default configuration options for Prometheus smartctl at [`roles/prometheus_smartctl/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/prometheus_smartctl/defaults/main.yml).
 Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
 
-{/* 
-
 ## Breaking Changes
 
-*/}
+### Switched from `matusnovak/prometheus-smartctl` to `prometheuscommunity/smartctl-exporter`
+
+The original [`matusnovak/prometheus-smartctl`](https://github.com/matusnovak/prometheus-smartctl) exporter has been archived and is no longer maintained (it also logged a recurring `'NoneType' object cannot be interpreted as an integer` exception on every scrape). This role now uses the actively-maintained [prometheus-community `smartctl_exporter`](https://github.com/prometheus-community/smartctl_exporter).
+
+**All exported metric names have changed** from the `smartprom_*` prefix to `smartctl_*`. If you have custom Grafana panels, alerts, or recording rules referencing `smartprom_*` metrics, you must update them. The bundled monitoring overview dashboard has already been updated.
+
+Common metric mappings:
+
+| Old (`smartprom_*`) | New (`smartctl_*`) |
+| --- | --- |
+| `smartprom_temperature_celsius_raw` | `smartctl_device_temperature{temperature_type="current"}` |
+| `smartprom_power_on_hours_raw` | `smartctl_device_power_on_seconds` (seconds — divide by `3600` for hours) |
+| `smartprom_power_cycle_count_raw` | `smartctl_device_power_cycle_count` |
+| `smartprom_<attribute>_raw` | `smartctl_device_attribute{attribute_name="<Attribute>", attribute_value_type="raw"}` |
+
+The per-disk label also changed from `drive="/dev/sda"` to `device="sda"`.
+
+No `group_vars` changes are required: the role still publishes metrics on host port `9902` (the new exporter listens on `9633` inside the container). It runs as `root` so `smartctl` can open the block devices.
 
 ## Recent Changes
 

--- a/roles/grafana/files/dashboard-overview.json
+++ b/roles/grafana/files/dashboard-overview.json
@@ -1996,8 +1996,8 @@
             "uid": "ansible_homelab_orchestration"
           },
           "editorMode": "code",
-          "expr": "smartprom_power_on_hours_raw",
-          "legendFormat": "{{drive}}",
+          "expr": "smartctl_device_power_on_seconds / 3600",
+          "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
         }
@@ -2088,8 +2088,8 @@
             "uid": "ansible_homelab_orchestration"
           },
           "editorMode": "code",
-          "expr": "smartprom_load_cycle_count_raw",
-          "legendFormat": "{{drive}}",
+          "expr": "smartctl_device_power_cycle_count",
+          "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
         }
@@ -2180,8 +2180,8 @@
             "uid": "ansible_homelab_orchestration"
           },
           "editorMode": "code",
-          "expr": "smartprom_start_stop_count_raw",
-          "legendFormat": "{{drive}}",
+          "expr": "smartctl_device_attribute{attribute_name=\"Start_Stop_Count\", attribute_value_type=\"raw\"}",
+          "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
         }

--- a/roles/prometheus_smartctl/defaults/main.yml
+++ b/roles/prometheus_smartctl/defaults/main.yml
@@ -2,11 +2,14 @@
 prometheus_smartctl_enabled: false
 
 # network
+# Host-published port (kept at 9902 so the Prometheus scrape config is unchanged);
+# the maintained exporter listens on 9633 inside the container.
 prometheus_smartctl_port: 9902
 
 # containers
 prometheus_smartctl_container_name: prometheus_smartctl
-prometheus_smartctl_image_name: matusnovak/prometheus-smartctl
+# Maintained prometheus-community exporter (replaces the archived matusnovak image).
+prometheus_smartctl_image_name: prometheuscommunity/smartctl-exporter
 prometheus_smartctl_image_version: latest
 
 prometheus_smartctl_container_names: # Used to check if app is running

--- a/roles/prometheus_smartctl/defaults/main.yml
+++ b/roles/prometheus_smartctl/defaults/main.yml
@@ -2,13 +2,10 @@
 prometheus_smartctl_enabled: false
 
 # network
-# Host-published port (kept at 9902 so the Prometheus scrape config is unchanged);
-# the maintained exporter listens on 9633 inside the container.
 prometheus_smartctl_port: 9902
 
 # containers
 prometheus_smartctl_container_name: prometheus_smartctl
-# Maintained prometheus-community exporter (replaces the archived matusnovak image).
 prometheus_smartctl_image_name: prometheuscommunity/smartctl-exporter
 prometheus_smartctl_image_version: latest
 

--- a/roles/prometheus_smartctl/tasks/main.yml
+++ b/roles/prometheus_smartctl/tasks/main.yml
@@ -14,8 +14,11 @@
         image: "{{ prometheus_smartctl_image_name }}:{{ prometheus_smartctl_image_version }}"
         pull: true
         privileged: true
+        # The prometheus-community image runs as a non-root user by default, which
+        # cannot open block devices even when privileged; smartctl needs root.
+        user: root
         ports:
-          - "{{ prometheus_smartctl_port }}:9902"
+          - "{{ prometheus_smartctl_port }}:9633"
         restart_policy: unless-stopped
         memory: "{{ prometheus_smartctl_memory }}"
 

--- a/roles/prometheus_smartctl/tasks/main.yml
+++ b/roles/prometheus_smartctl/tasks/main.yml
@@ -14,8 +14,7 @@
         image: "{{ prometheus_smartctl_image_name }}:{{ prometheus_smartctl_image_version }}"
         pull: true
         privileged: true
-        # The prometheus-community image runs as a non-root user by default, which
-        # cannot open block devices even when privileged; smartctl needs root.
+        # https://github.com/prometheus-community/smartctl_exporter#why-is-root-required-cant-i-add-a-user-to-the-disk-group
         user: root
         ports:
           - "{{ prometheus_smartctl_port }}:9633"


### PR DESCRIPTION
## ⚠️ Breaking change
Switches the smartctl exporter from the archived `matusnovak/prometheus-smartctl` to the actively-maintained prometheus-community `smartctl_exporter` (`prometheuscommunity/smartctl-exporter`). The old image is archived and logged a recurring `'NoneType' object cannot be interpreted as an integer` exception on every scrape.

**All metric names change** from the `smartprom_*` prefix to `smartctl_*`, and the per-disk label changes from `drive="/dev/sda"` to `device="sda"`. This PR:
- updates the bundled monitoring overview dashboard to the new metrics, and
- documents the migration (with a metric-mapping table) in the Breaking Changes section of the `prometheus_smartctl` docs.

The commit subject uses the `feat(prometheus_smartctl)!:` form so the repo's breaking-change detection fires.

## Notes
- The new image listens on 9633 internally; the role still publishes host port 9902, so the Prometheus scrape config is unchanged.
- The image runs as a non-root user by default and cannot open block devices even when privileged, so the container now runs as `root`.

## Testing
- `python tests/test.py` passes.
- Verified on a live host: drives are read (no permission errors), the `NoneType` exception is gone, and all three updated dashboard panels populate with correct values.
