### PR TITLE
feat(tssk): Add TSSK (TV Show Status for Kometa)

### DIFF
--- a/docs/src/content/docs/applications/tssk.mdx
+++ b/docs/src/content/docs/applications/tssk.mdx
@@ -1,0 +1,35 @@
+---
+title: TV-show-status-for-Kometa
+tags: ["TV"]
+---
+
+import Tags from "../../../components/Tags.astro"
+import RecentChanges from "../../../components/RecentChanges.astro"
+
+[Repository](https://github.com/netplexflix/TV-show-status-for-Kometa)
+
+<Tags tags={frontmatter.tags} />
+
+TSSK (TV Show Status for Kometa) checks your Sonarr for your TV Shows statuses and creates .yml files which can be used by Kometa to create collections and overlays.
+
+## Setting up
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+tssk_enabled: true
+```
+
+
+## Configuration
+
+See the default configuration options for TV-show-status-for-Kometa at [`roles/tssk/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/tssk/defaults/main.yml).
+Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
+
+{/* 
+
+## Breaking Changes
+
+*/}
+
+## Recent Changes
+
+<RecentChanges application="tssk" />

--- a/playbook.yml
+++ b/playbook.yml
@@ -466,6 +466,10 @@
       tags: ttrss
       when: ttrss_enabled or (ttrss_container_names | intersect(running_containers) | length > 0)
 
+    - role: tssk
+      tags: tssk
+      when: tssk_enabled or (tssk_container_names | intersect(running_containers) | length > 0)
+
     - role: ubooquity
       tags: ubooquity
       when: ubooquity_enabled or (ubooquity_container_names | intersect(running_containers) | length > 0)

--- a/roles/tssk/defaults/main.yml
+++ b/roles/tssk/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+tssk_enabled: false
+
+# directories
+tssk_data_directory: "{{ docker_home }}/tssk/"
+tssk_config_directory: "{{ docker_home }}/tssk/config/"
+
+
+# containers
+tssk_container_name: tssk
+tssk_image_name: netplexflix/tssk
+tssk_image_version: latest
+
+tssk_container_names: # Used to check if app is running
+  - "{{ tssk_container_name }}"
+
+# specs
+tssk_memory: 1g
+
+# config
+tssk_environment_variables:
+  CRON: 0 0,12 * * *   # every day at midnight and noon
+  DOCKER: "true" # important for path reference

--- a/roles/tssk/tasks/main.yml
+++ b/roles/tssk/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Start TV-show-status-for-Kometa
+  when: tssk_enabled
+  block:
+    - name: Check for TV-show-status-for-Kometa Breaking Changes
+      ansible.builtin.include_role:
+        name: breaking_changes
+      vars:
+        breaking_changes_application: tssk
+
+    - name: Check for Kometa installation
+      ansible.builtin.fail:
+        msg: "TSSK requires Kometa enabled and running, please set that up first."
+      when: kometa_enabled is false
+
+    - name: Create TV-show-status-for-Kometa Directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ tssk_data_directory }}"
+        - "{{ tssk_config_directory }}"
+
+    - name: TV-show-status-for-Kometa Docker Container
+      community.docker.docker_container:
+        name: "{{ tssk_container_name }}"
+        image: "{{ tssk_image_name }}:{{ tssk_image_version }}"
+        pull: true
+        volumes:
+          - "{{ tssk_config_directory }}:/app/config:rw"
+          - "{{ kometa_config_directory }}:/config/kometa:rw"
+        env: "{{ tssk_environment_variables }}"
+        restart_policy: unless-stopped
+        memory: "{{ tssk_memory }}"
+
+- name: Stop TV-show-status-for-Kometa
+  when: not tssk_enabled
+  block:
+    - name: Stop TV-show-status-for-Kometa
+      community.docker.docker_container:
+        name: "{{ tssk_container_name }}"
+        state: absent


### PR DESCRIPTION
Adds the **TSSK** (TV Show Status for Kometa) application. TSSK reads Sonarr for TV-show statuses and writes `.yml` files that Kometa consumes to build collections and overlays, so it complements the existing `kometa` role.

Built with the standard role layout (defaults + tasks), a docs page, and a `playbook.yml` entry. Also fixed a stray `{...}` wrapping the docs Repository link.

## Testing
- `python tests/test.py` passes (no port/hostname conflicts).
