### PR TITLE
feat(kometa): Add configurable memory_swap limit

### DIFF
--- a/roles/kometa/defaults/main.yml
+++ b/roles/kometa/defaults/main.yml
@@ -15,6 +15,7 @@ kometa_container_names: # Used to check if app is running
 
 # specs
 kometa_memory: 1g
+kometa_memory_swap: 1g
 
 # config
 kometa_run_immediately: false # If true, Kometa will run immediately after startup instead of waiting until the scheduled times

--- a/roles/kometa/tasks/main.yml
+++ b/roles/kometa/tasks/main.yml
@@ -29,6 +29,7 @@
           TZ: "{{ computer_timezone }}"
         restart_policy: unless-stopped
         memory: "{{ kometa_memory }}"
+        memory_swap: "{{ kometa_memory_swap }}"
 
 - name: Stop Kometa
   when: not kometa_enabled


### PR DESCRIPTION
Adds a `kometa_memory_swap` option, passed to the container's `memory_swap`. Kometa is memory-intensive and previously only `memory` was set, leaving the container's swap effectively unbounded. Defaults to the same `1g` as `kometa_memory` so swap is bounded by default; override in group_vars to allow more.

## Testing
- `python tests/test.py` passes.
