### PR TITLE
fix(homebox): Set required HBOX_AUTH_API_KEY_PEPPER so the container starts

### DIFF
--- a/docs/src/content/docs/applications/homebox.mdx
+++ b/docs/src/content/docs/applications/homebox.mdx
@@ -26,6 +26,16 @@ By default, HomeBox can be accessed at `http://[your_server_ip]:7745` or `https:
 See the default configuration options for HomeBox at [`roles/homebox/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/homebox/defaults/main.yml).
 Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
 
+### API key signing secret
+
+HomeBox requires an API key signing secret (`HBOX_AUTH_API_KEY_PEPPER`) of at least 32 bytes, or it will refuse to start. The role provides a placeholder default so HomeBox runs out of the box, but you should set your own:
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+homebox_api_key_pepper: "your-own-secret" # generate one with: openssl rand -base64 48
+```
+
+Rotating this value invalidates all previously issued API keys.
+
 {/* 
 
 ## Breaking Changes

--- a/roles/homebox/defaults/main.yml
+++ b/roles/homebox/defaults/main.yml
@@ -21,3 +21,9 @@ homebox_container_names: # Used to check if app is running
 # specs
 homebox_memory: 1g
 homebox_log_level: info
+
+# auth
+# Secret used to sign API keys (HomeBox requires at least 32 bytes).
+# CHANGE THIS to your own value! Generate one with: openssl rand -base64 48
+# Note: rotating this invalidates all previously issued API keys.
+homebox_api_key_pepper: Y2hhbmdlLXRoaXMtcGVwcGVyLWdlbmVyYXRlLXdpdGgtb3BlbnNzbC1yYW5kLWJhc2U2NC00OA==

--- a/roles/homebox/tasks/main.yml
+++ b/roles/homebox/tasks/main.yml
@@ -26,6 +26,7 @@
           HBOX_LOG_LEVEL: "{{ homebox_log_level }}"
           HBOX_LOG_FORMAT: "text"
           HBOX_WEB_MAX_FILE_UPLOAD: "10"
+          HBOX_AUTH_API_KEY_PEPPER: "{{ homebox_api_key_pepper }}"
         ports:
           - "{{ homebox_port }}:7745"
         restart_policy: unless-stopped


### PR DESCRIPTION
## What
Adds the now-required `HBOX_AUTH_API_KEY_PEPPER` env var to the HomeBox container, via a new `homebox_api_key_pepper` variable with a placeholder default.

## Why
Recent HomeBox versions require `auth.api_key_pepper` to be at least 32 bytes and **panic on startup** otherwise:

```
panic: auth.api_key_pepper must be set to at least 32 bytes; generate with
`openssl rand -base64 48` and provide via HBOX_AUTH_API_KEY_PEPPER.
```

The role didn't set this, so once the container auto-updated to such a version it **crash-looped** (panic + restart ~once a minute) and HomeBox was unreachable.

## Approach
- New `homebox_api_key_pepper` default, passed through as `HBOX_AUTH_API_KEY_PEPPER`.
- The default is a valid base64 placeholder so HomeBox starts out of the box, matching the existing convention for default secrets (e.g. firefly's `APP_KEY`).
- Docs updated: users should set their own value (`openssl rand -base64 48`), and rotating it invalidates issued API keys.

## Testing
- `python tests/test.py` passes.
- Reproduced the crash-loop from logs on a live host (panic every ~60s); the missing env var is the cause.
