### PR TITLE
fix(teamspeak3): Do not override the container user

### DIFF
--- a/docs/src/content/docs/applications/teamspeak3.mdx
+++ b/docs/src/content/docs/applications/teamspeak3.mdx
@@ -39,6 +39,10 @@ telegraf_teamspeak3_serverquery_password: serverquerypass
 See the default configuration options for TeamSpeak 3 at [`roles/teamspeak3/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/teamspeak3/defaults/main.yml).
 Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
 
+### Container user
+
+The TeamSpeak container runs as its built-in user (UID `9987`) and does not support overriding the user via PUID/PGID. Forcing a custom `user:` breaks the server's access to its own `/files` and `/logs` directories ([upstream issue](https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images/issues/51)), so the role intentionally does not set one. As a result, files created in the mounted `teamspeak3_data_directory` are owned by UID `9987` on the host.
+
 ### TeamSpeak License
 
 A TeamSpeak server requires a license file when using more then 1 virtual server with 32 slots.

--- a/roles/teamspeak3/defaults/main.yml
+++ b/roles/teamspeak3/defaults/main.yml
@@ -10,9 +10,6 @@ teamspeak3_ip_whitelist: "" # Comma separated list of IPs that are allowed to co
 teamspeak3_ip_blacklist: "" # Comma separated list of IPs that are blocked from connecting to the server, leave empty to block none
 teamspeak3_query_protocols: "raw,ssh" # Comma separated list of query protocols to enable, options are raw and ssh
 
-teamspeak3_user_id: "1000"
-teamspeak3_group_id: "1000"
-
 # network
 teamspeak3_hostname: teamspeak3
 teamspeak3_port: 9987

--- a/roles/teamspeak3/tasks/main.yml
+++ b/roles/teamspeak3/tasks/main.yml
@@ -32,7 +32,10 @@
           TS3SERVER_IP_WHITELIST: "{{ teamspeak3_ip_whitelist }}"
           TS3SERVER_IP_BLACKLIST: "{{ teamspeak3_ip_blacklist }}"
           TS3SERVER_QUERY_PROTOCOLS: "{{ teamspeak3_query_protocols }}"
-        user: "{{ teamspeak3_user_id }}:{{ teamspeak3_group_id }}"
+        # The TeamSpeak image runs as its built-in user (UID 9987) and does not
+        # support PUID/PGID. Overriding `user:` breaks the server's access to its
+        # own /files and /logs directories, so it is intentionally not set.
+        # https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images/issues/51
         restart_policy: unless-stopped
         memory: "{{ teamspeak3_memory }}"
         labels:


### PR DESCRIPTION
## What
Stops the `teamspeak3` role from overriding the container user, and removes the now-unused `teamspeak3_user_id` / `teamspeak3_group_id` defaults.

## Why
The TeamSpeak image runs as its built-in user (UID `9987`) and does not support PUID/PGID. The role set `user: "{{ teamspeak3_user_id }}:{{ teamspeak3_group_id }}"` (default `1000:1000`), which breaks the server's access to its own `/files` and `/logs` directories — newly created channel folders become unwritable and the server hits permission failures.

See upstream issue: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images/issues/51

## Approach
- Drop the `user:` override and leave the container running as its built-in user.
- Remove the two defaults that only fed that line.
- Add a short comment (with the issue link) in the role so it isn't re-added, and a "Container user" note in the docs explaining that data-directory files are owned by UID `9987` on the host.

## Note
The sister `teamspeak6` role has the same `user:` pattern and is likely affected too, but I've only verified and fixed `teamspeak3` here.

## Testing
- `python tests/test.py` passes.
- Verified on a live host: removing the `user:` override resolves the permission failures and the server runs normally.
