### PR TITLE
feat(traefik): Make the Traefik container DNS servers configurable

### DIFF
--- a/docs/src/content/docs/applications/traefik.mdx
+++ b/docs/src/content/docs/applications/traefik.mdx
@@ -19,6 +19,20 @@ Traefik (pronounced traffic) is a modern HTTP reverse proxy and load balancer th
   Please refer to the [DNS Access Guide](/../../guides/dns-access/) for instructions on how to set up Traefik for DNS access.
 </Aside>
 
+## Configuration
+
+### DNS resolution (split-horizon DNS)
+
+Traefik determines the backend address for a host-network application (one that runs with `network_mode: host`, such as Home Assistant, Netdata, or Plex) by resolving your host's FQDN. By default the Traefik container resolves names using `8.8.8.8`.
+
+If you use **split-horizon DNS** — where your host name resolves to a **public** IP externally but a **private LAN** IP internally — the default `8.8.8.8` returns the public IP. Traefik then routes host-network backends to that public IP, which fails for any service whose port is not forwarded, returning **502 Bad Gateway** (for example, Home Assistant on port 8123).
+
+To fix this, point Traefik at your LAN resolver so those backends resolve to the internal LAN address:
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+traefik_dns_servers: ["192.168.1.1"] # your LAN DNS resolver
+```
+
 {/* 
 
 ## Breaking Changes

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -25,6 +25,15 @@ traefik_http_port: 80
 traefik_https_port: 443
 traefik_ui_port: 8083
 
+# DNS server(s) the Traefik container uses to resolve service backends.
+# Traefik determines the backend for a host-network service (network_mode: host)
+# by resolving the host's FQDN. If you use split-horizon DNS -- your host name
+# resolves to a PUBLIC IP externally but a PRIVATE LAN IP internally -- set this
+# to your LAN resolver so those backends resolve to the internal LAN address.
+# Otherwise Traefik routes them to the public IP and returns 502 for any service
+# whose port is not forwarded (e.g. Home Assistant).
+traefik_dns_servers: ["8.8.8.8"]
+
 # containers
 traefik_container_name: traefik
 traefik_image_name: traefik

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -43,7 +43,7 @@
         restart_policy: unless-stopped
         memory: "{{ traefik_memory }}"
         recreate: "{{ traefik_template_static_config is changed or traefik_template_dynamic_config is changed }}"
-        dns_servers: ["8.8.8.8"]
+        dns_servers: "{{ traefik_dns_servers }}"
         labels:
           traefik.enable: "{{ (traefik_dns_accessible or traefik_available_externally) | string }}"
           traefik.http.services.traefik.loadbalancer.server.port: "{{ traefik_ui_port }}"


### PR DESCRIPTION
## What
Makes the Traefik container's DNS servers configurable via a new `traefik_dns_servers` variable (default unchanged: `["8.8.8.8"]`).

## Why
The container's DNS was hardcoded to `8.8.8.8`. Traefik builds the backend address for a host-network service (`network_mode: host`, e.g. Home Assistant, Netdata, Plex) by resolving the host's FQDN. On a **split-horizon DNS** setup — where the host name resolves to a public IP externally but a private LAN IP internally — `8.8.8.8` returns the public IP, so Traefik routes those backends to the public IP and returns **502 Bad Gateway** for any such service whose port isn't forwarded (Home Assistant, Netdata). Plex only worked because 32400 happened to be port-forwarded.

## Change
- `roles/traefik/tasks/main.yml`: `dns_servers: "{{ traefik_dns_servers }}"`.
- `roles/traefik/defaults/main.yml`: add `traefik_dns_servers: ["8.8.8.8"]` with a comment explaining the split-horizon rationale.
- `docs/.../traefik.mdx`: a "DNS resolution (split-horizon DNS)" section documenting when/why to override it.

**Not a breaking change** — the default equals the previous hardcoded value, so existing deployments are byte-for-byte unchanged unless they opt in.

## Testing
- `python tests/test.py` passes.
- Verified on a live split-horizon host: with `traefik_dns_servers: ["192.168.1.1"]`, Traefik's HA backend changed from `http://<public-ip>:8123` to `http://192.168.1.3:8123`, and `https://homeassistant.lathrum.com` went from 502 to 200 (netdata too; plex unaffected).
