### PR TITLE
feat(watchtower): Add optional Prometheus metrics endpoint

### DIFF
--- a/docs/src/content/docs/applications/watchtower.mdx
+++ b/docs/src/content/docs/applications/watchtower.mdx
@@ -37,7 +37,12 @@ watchtower_enabled: true
 ```
 Watchtower will automatically monitor and update all other Docker containers.
 
-## Prometheus metrics
+## Configuration
+
+See the default configuration options for Watchtower at [`roles/watchtower/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/watchtower/defaults/main.yml).
+Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
+
+### Prometheus metrics
 
 Watchtower can publish metrics (containers scanned/updated/failed/skipped, scan counts) to
 [Prometheus](../prometheus/) for monitoring. This requires `prometheus_enabled: true`.
@@ -51,7 +56,7 @@ watchtower_metrics_token: "your-generated-token"
 watchtower_ephemeral_self_update_enabled: true
 ```
 
-Prometheus scrapes `/v1/metrics` on `watchtower_metrics_port` (default `8080`)
+Prometheus scrapes `/v1/metrics` on `watchtower_metrics_port` (default `8081`)
 automatically. Import the dashboard from the Watchtower repo's
 `examples/metrics/grafana/dashboards/dashboard.json` to visualize the data.
 
@@ -62,11 +67,6 @@ automatically. Import the dashboard from the Watchtower repo's
 	orchestrator (experimental) so Watchtower keeps self-updating. If a self-update fails,
 	the existing container is preserved. All other containers update normally regardless.
 </Aside>
-
-## Configuration
-
-See the default configuration options for Watchtower at [`roles/watchtower/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/watchtower/defaults/main.yml).
-Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
 
 {/* 
 

--- a/docs/src/content/docs/applications/watchtower.mdx
+++ b/docs/src/content/docs/applications/watchtower.mdx
@@ -37,6 +37,32 @@ watchtower_enabled: true
 ```
 Watchtower will automatically monitor and update all other Docker containers.
 
+## Prometheus metrics
+
+Watchtower can publish metrics (containers scanned/updated/failed/skipped, scan counts) to
+[Prometheus](../prometheus/) for monitoring. This requires `prometheus_enabled: true`.
+
+Enable it and set a bearer token Prometheus uses to authenticate — generate one with
+`openssl rand -hex 32`:
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+watchtower_metrics_enabled: true
+watchtower_metrics_token: "your-generated-token"
+watchtower_ephemeral_self_update_enabled: true
+```
+
+Prometheus scrapes `/v1/metrics` on `watchtower_metrics_port` (default `8080`)
+automatically. Import the dashboard from the Watchtower repo's
+`examples/metrics/grafana/dashboards/dashboard.json` to visualize the data.
+
+<Aside type="caution">
+	Publishing the metrics port would normally make Watchtower skip updating its **own**
+	container (to avoid a port conflict on self-recreation). Setting
+	`watchtower_ephemeral_self_update_enabled: true` uses the fork's ephemeral self-update
+	orchestrator (experimental) so Watchtower keeps self-updating. If a self-update fails,
+	the existing container is preserved. All other containers update normally regardless.
+</Aside>
+
 ## Configuration
 
 See the default configuration options for Watchtower at [`roles/watchtower/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/watchtower/defaults/main.yml).

--- a/roles/prometheus/defaults/main.yml
+++ b/roles/prometheus/defaults/main.yml
@@ -36,3 +36,7 @@ prometheus_collection_interval: 15s
 
 # uncomment to scrape metrics from HomeAssistant. You'll need to create a long lived access token.
 # prometheus_homeassistant_long_lived_access_token: abcd
+
+# To scrape Watchtower's metrics, enable it in the Watchtower role (see roles/watchtower/defaults/main.yml):
+# watchtower_metrics_enabled: true
+# watchtower_metrics_token: "<bearer token>"

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -70,3 +70,14 @@ scrape_configs:
                     "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:8123"
                  ]
 {% endif %}
+
+{% if watchtower_metrics_enabled | default(false) %}
+  - job_name: "watchtower"
+    metrics_path: /v1/metrics
+    authorization:
+      credentials: "{{ watchtower_metrics_token | default('') }}"
+    static_configs:
+      - targets: [
+                    "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ watchtower_metrics_port | default(8080) }}"
+                 ]
+{% endif %}

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -75,9 +75,9 @@ scrape_configs:
   - job_name: "watchtower"
     metrics_path: /v1/metrics
     authorization:
-      credentials: "{{ watchtower_metrics_token | default('') }}"
+      credentials: "{{ watchtower_metrics_token }}"
     static_configs:
       - targets: [
-                    "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ watchtower_metrics_port | default(8080) }}"
+                    "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ watchtower_metrics_port }}"
                  ]
 {% endif %}

--- a/roles/watchtower/defaults/main.yml
+++ b/roles/watchtower/defaults/main.yml
@@ -29,3 +29,18 @@ watchtower_container_names: # Used to check if app is running
 
 # specs
 watchtower_memory: 1g
+
+# --- Prometheus metrics ---
+# Expose Watchtower's HTTP metrics endpoint (/v1/metrics on container port 8080).
+# Watchtower's HTTP API requires a token, so this is always authenticated.
+watchtower_metrics_enabled: false
+# Host port to publish the metrics endpoint on (container's internal API port is always 8080).
+watchtower_metrics_port: 8081
+# Bearer token required to scrape the endpoint. Set this in your inventory (keep it secret).
+watchtower_metrics_token: ""
+
+# Publishing a port normally makes Watchtower skip updating its OWN container (to avoid a
+# host-port conflict on recreation). Enabling this uses the fork's ephemeral self-update
+# orchestrator (v1.16.0+, experimental) so Watchtower keeps self-updating even with a port
+# mapped. Recommended when watchtower_metrics_enabled is true on a set-and-forget host.
+watchtower_ephemeral_self_update_enabled: false

--- a/roles/watchtower/defaults/main.yml
+++ b/roles/watchtower/defaults/main.yml
@@ -31,12 +31,11 @@ watchtower_container_names: # Used to check if app is running
 watchtower_memory: 1g
 
 # --- Prometheus metrics ---
-# Expose Watchtower's HTTP metrics endpoint (/v1/metrics on container port 8080).
-# Watchtower's HTTP API requires a token, so this is always authenticated.
+# Expose Watchtower's HTTP metrics endpoint `/v1/metrics`.
 watchtower_metrics_enabled: false
-# Host port to publish the metrics endpoint on (container's internal API port is always 8080).
+# Host port to publish the metrics endpoint on
 watchtower_metrics_port: 8081
-# Bearer token required to scrape the endpoint. Set this in your inventory (keep it secret).
+# Bearer token Prometheus uses to authenticate; generate with `openssl rand -hex 32` (keep it secret).
 watchtower_metrics_token: ""
 
 # Publishing a port normally makes Watchtower skip updating its OWN container (to avoid a

--- a/roles/watchtower/tasks/main.yml
+++ b/roles/watchtower/tasks/main.yml
@@ -15,17 +15,13 @@
         pull: true
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
-        env: >-
-          {{
-            {'TZ': computer_timezone}
-            | combine({'WATCHTOWER_HTTP_API_METRICS': 'true',
-                       'WATCHTOWER_HTTP_API_TOKEN': watchtower_metrics_token}
-                      if watchtower_metrics_enabled else {})
-            | combine({'WATCHTOWER_EPHEMERAL_SELF_UPDATE': 'true'}
-                      if watchtower_ephemeral_self_update_enabled else {})
-          }}
+        env:
+          TZ: "{{ computer_timezone }}"
+          WATCHTOWER_HTTP_API_METRICS: "{{ 'true' if watchtower_metrics_enabled else 'false' }}"
+          WATCHTOWER_HTTP_API_TOKEN: "{{ watchtower_metrics_token }}"
+          WATCHTOWER_EPHEMERAL_SELF_UPDATE: "{{ 'true' if watchtower_ephemeral_self_update_enabled else 'false' }}"
         command: "{{ watchtower_command }}"
-        ports: "{{ ['%d:8080' | format(watchtower_metrics_port | int)] if watchtower_metrics_enabled else omit }}"
+        ports: "{{ [watchtower_metrics_port ~ ':8080'] if watchtower_metrics_enabled else omit }}"
         restart_policy: unless-stopped
         memory: "{{ watchtower_memory }}"
 

--- a/roles/watchtower/tasks/main.yml
+++ b/roles/watchtower/tasks/main.yml
@@ -15,9 +15,17 @@
         pull: true
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
-        env:
-          TZ: "{{ computer_timezone }}"
+        env: >-
+          {{
+            {'TZ': computer_timezone}
+            | combine({'WATCHTOWER_HTTP_API_METRICS': 'true',
+                       'WATCHTOWER_HTTP_API_TOKEN': watchtower_metrics_token}
+                      if watchtower_metrics_enabled else {})
+            | combine({'WATCHTOWER_EPHEMERAL_SELF_UPDATE': 'true'}
+                      if watchtower_ephemeral_self_update_enabled else {})
+          }}
         command: "{{ watchtower_command }}"
+        ports: "{{ ['%d:8080' | format(watchtower_metrics_port | int)] if watchtower_metrics_enabled else omit }}"
         restart_policy: unless-stopped
         memory: "{{ watchtower_memory }}"
 


### PR DESCRIPTION
## What

Adds an **optional, default-off** Prometheus metrics endpoint for Watchtower, plus a gated Prometheus scrape job, so the community Watchtower Grafana dashboards can actually be populated.

## Why

Watchtower exposes a Prometheus-compatible `/v1/metrics` endpoint, but the role had no way to turn it on (no metrics flags, no published port, no scrape job). As a result the dashboards stay empty. This wires the whole path with a single opt-in flag.

## How

New variables in `roles/watchtower/defaults/main.yml` (all default-off):

| Variable | Default | Purpose |
|---|---|---|
| `watchtower_metrics_enabled` | `false` | Enable the metrics endpoint + publish the port |
| `watchtower_metrics_port` | `8081` | Host port to publish (container API is always `8080`) |
| `watchtower_metrics_token` | `""` | Bearer token (set in inventory) |
| `watchtower_ephemeral_self_update_enabled` | `false` | Keep self-update working with a port mapped |

- When `watchtower_metrics_enabled`, the container task adds `WATCHTOWER_HTTP_API_METRICS` + `WATCHTOWER_HTTP_API_TOKEN` to the env and publishes `{{ watchtower_metrics_port }}:8080`. `watchtower_command` is left untouched.
- `roles/prometheus/templates/prometheus.yml.j2` gets a gated `watchtower` scrape job with `metrics_path: /v1/metrics` and bearer auth via `authorization: credentials:` — the same pattern the existing Home Assistant job uses.

### Self-update caveat (why the ephemeral flag exists)

Watchtower skips updating its **own** container when a port is mapped (to avoid a host-port conflict on recreation). For set-and-forget hosts that would let Watchtower drift. `watchtower_ephemeral_self_update_enabled` opts into Watchtower's ephemeral self-update orchestrator so self-update keeps working even with the metrics port published. (It only affects how Watchtower updates *itself*; other containers are unaffected. The orchestrator is marked experimental upstream, hence opt-in.)

## Backward compatibility

With both flags at their defaults (`false`), the rendered container env/ports and the Prometheus config are **byte-for-byte identical** to today — existing users see no change. The metrics host port defaults to `8081` specifically to avoid colliding with `nextcloud_port` (8080).

## Docs

`docs/.../watchtower.mdx` gains a "Prometheus metrics" section (modeled on the Home Assistant integration doc) with the group_vars to set, how to generate a token, and a caution about the self-update/ephemeral trade-off. `roles/prometheus/defaults/main.yml` gets a discoverability comment mirroring the existing Home Assistant token hint.

## Testing

- `python tests/test.py` — passes (port-conflict check included; this is what flagged 8080 vs nextcloud, now 8081).
- `ansible-lint` — passes at the `production` profile.
- Deployed against a live host: endpoint returns `200` with `watchtower_*` series, Prometheus target is `up`, Grafana panels populate, and `docker logs` confirm self-update is not skipped with the ephemeral flag enabled.
