### PR TITLE
fix(teamspeak3): make ServerQuery IP allow/block lists take effect

### DIFF
--- a/docs/src/content/docs/applications/teamspeak3.mdx
+++ b/docs/src/content/docs/applications/teamspeak3.mdx
@@ -39,6 +39,20 @@ telegraf_teamspeak3_serverquery_password: serverquerypass
 See the default configuration options for TeamSpeak 3 at [`roles/teamspeak3/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/teamspeak3/defaults/main.yml).
 Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
 
+### ServerQuery IP allow/block lists
+
+The ServerQuery interface is rate-limited by flood protection, which can interfere with tools that
+poll it frequently (for example a web viewer). Add their IPs to `teamspeak3_ip_whitelist` to exempt
+them from flood protection; use `teamspeak3_ip_blacklist` to bar IPs from ServerQuery entirely.
+Both are comma separated and rendered into the `query_ip_allowlist.txt` / `query_ip_blocklist.txt`
+files the server reads. Localhost is included in the allowlist by default — keep it so local
+queries (such as [Telegraf](../telegraf/)) keep working.
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+# e.g. exempt a containerized viewer reaching TeamSpeak from the Docker bridge
+teamspeak3_ip_whitelist: "127.0.0.1,::1,172.17.0.0/16"
+```
+
 ### TeamSpeak License
 
 A TeamSpeak server requires a license file when using more then 1 virtual server with 32 slots.

--- a/roles/teamspeak3/defaults/main.yml
+++ b/roles/teamspeak3/defaults/main.yml
@@ -6,8 +6,10 @@ teamspeak3_available_externally: false
 # directories
 teamspeak3_data_directory: "{{ docker_home }}/teamspeak3/"
 
-teamspeak3_ip_whitelist: "" # Comma separated list of IPs that are allowed to connect to the server, leave empty to allow all
-teamspeak3_ip_blacklist: "" # Comma separated list of IPs that are blocked from connecting to the server, leave empty to block none
+# Comma separated IPs exempt from ServerQuery flood protection. Localhost is included by default so
+# local queries (e.g. telegraf) keep working; override the whole list to add or change entries.
+teamspeak3_ip_whitelist: "127.0.0.1,::1"
+teamspeak3_ip_blacklist: "" # Comma separated IPs to bar from ServerQuery entirely
 teamspeak3_query_protocols: "raw,ssh" # Comma separated list of query protocols to enable, options are raw and ssh
 
 teamspeak3_user_id: "1000"

--- a/roles/teamspeak3/tasks/main.yml
+++ b/roles/teamspeak3/tasks/main.yml
@@ -15,6 +15,15 @@
       with_items:
         - "{{ teamspeak3_data_directory }}"
 
+    - name: Template TeamSpeak 3 ServerQuery IP allow/block lists
+      ansible.builtin.template:
+        src: "{{ item }}.j2"
+        dest: "{{ teamspeak3_data_directory }}/{{ item }}"
+        mode: "0644"
+      with_items:
+        - query_ip_allowlist.txt
+        - query_ip_blocklist.txt
+
     - name: TeamSpeak 3 Docker Container
       community.docker.docker_container:
         name: "{{ teamspeak3_container_name }}"
@@ -29,8 +38,6 @@
           - "{{ teamspeak3_filebrowser_port }}:30033"
         env:
           TS3SERVER_LICENSE: accept
-          TS3SERVER_IP_WHITELIST: "{{ teamspeak3_ip_whitelist }}"
-          TS3SERVER_IP_BLACKLIST: "{{ teamspeak3_ip_blacklist }}"
           TS3SERVER_QUERY_PROTOCOLS: "{{ teamspeak3_query_protocols }}"
         user: "{{ teamspeak3_user_id }}:{{ teamspeak3_group_id }}"
         restart_policy: unless-stopped

--- a/roles/teamspeak3/templates/query_ip_allowlist.txt.j2
+++ b/roles/teamspeak3/templates/query_ip_allowlist.txt.j2
@@ -1,0 +1,1 @@
+{{ (teamspeak3_ip_whitelist.split(',') | map('trim') | select | list) | join('\n') }}

--- a/roles/teamspeak3/templates/query_ip_blocklist.txt.j2
+++ b/roles/teamspeak3/templates/query_ip_blocklist.txt.j2
@@ -1,0 +1,1 @@
+{{ (teamspeak3_ip_blacklist.split(',') | map('trim') | select | list) | join('\n') }}


### PR DESCRIPTION
## Problem

`teamspeak3_ip_whitelist` / `teamspeak3_ip_blacklist` don't take effect. They're passed as
`TS3SERVER_IP_WHITELIST` / `_BLACKLIST`, which current `teamspeak` images ignore — the entrypoint
only reads `TS3SERVER_IP_ALLOWLIST` / `_BLOCKLIST`, and those are *file paths*, not IP lists. So the
values are silently dropped and the ServerQuery allow/block lists stay at their built-in defaults.

## Fix

Render the vars into `query_ip_allowlist.txt` / `query_ip_blocklist.txt` — the files the server
actually reads — so they apply. The localhost defaults live in `defaults/main.yml` (not hardcoded in
the template) so the list stays fully overridable; an unset var reproduces the stock allowlist,
leaving existing behaviour unchanged.

Non-breaking: variable names and comma-separated format are unchanged.

## Testing

- `python tests/test.py` passes.
- Verified on a live host: the templated allowlist loads (`CIDRManager` logs the configured IPs) and
  a whitelisted source IP is exempt from the ServerQuery flood ban while an unlisted one is not.

> Note: orthogonal to #12 (container-user fix) — the diffs don't overlap, though both are needed for
> a clean recreate against current images.
