### PR TITLE
fix(alloy): pin container hostname so host log/metric labels are stable

### DIFF
--- a/roles/alloy/tasks/main.yml
+++ b/roles/alloy/tasks/main.yml
@@ -27,6 +27,13 @@
       community.docker.docker_container:
         name: "{{ alloy_container_name }}"
         image: "{{ alloy_image_name }}:{{ alloy_image_version }}"
+        # Pin the container hostname so Alloy's `constants.hostname` resolves to
+        # the host rather than the random Docker container ID. Alloy runs
+        # in-container and builds the journal/syslog/node-metrics labels from
+        # that constant, so without this the host's logs and metrics are labeled
+        # with an unstable container ID that forks into a brand new source every
+        # time the container is recreated.
+        hostname: "{{ inventory_hostname }}"
         pull: true
         volumes:
           - "{{ alloy_config_directory }}/config.alloy:/etc/alloy/config.alloy:rw"


### PR DESCRIPTION
## What

Pin the Alloy container's hostname to `inventory_hostname` so Alloy's `constants.hostname` resolves to the host it is monitoring instead of a random Docker container ID.

## Why

Alloy runs inside a Docker container, and `config.alloy` builds all of the host-source labels from `constants.hostname`:

| Source | Label | Value |
| --- | --- | --- |
| journal | `component` | `<hostname>-journal` |
| syslog | `job` | `<hostname>-logs` |
| node metrics | `instance` | `<hostname>` |
| node metrics | `job` | `<hostname>-metrics` |

Since Alloy reads *its own container's* hostname, `constants.hostname` is the short container ID Docker assigns at creation (e.g. `83d25e5f7b3f`), not the host. That ID is regenerated **every time the container is recreated** — image upgrades, `docker_container` re-runs, Watchtower, etc. So on every recreate the host's journal, syslog, and node metrics fork into a brand-new set of source names.

Loki compounds it: it auto-derives `service_name` from the `component`/`job` values, so the host's own logs end up scattered across a pile of unstable, machine-generated series names that are awkward to query and never line up historically.

## The fix

Setting the container's `hostname` to `inventory_hostname` makes `constants.hostname` stable and human-readable (e.g. `excalibur`). Sources become `excalibur-journal` / `excalibur-logs` / `excalibur-metrics` and stay consistent across recreates. This mirrors how the existing **netdata** role already pins its container hostname.

## Impact / backward compatibility

On the first deploy after this change, the host log/metric labels move from the old container-ID values to the host name. Because the previous values were non-deterministic (a fresh hash per container lifetime), nothing could reliably reference them, so **no manual action is required** — the old series simply age out under normal retention. I've left this as a non-breaking `fix`; happy to add the `!` and a Breaking Changes docs entry if you'd prefer to surface it through the breaking-changes gate.

## Testing

- `python3 tests/test.py` → 0 failures
- `ansible-lint roles/alloy/` → 0 failures / 0 warnings (`production` profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
