### PR TITLE
feat(dashy): support serving local item icons

### DIFF
--- a/docs/src/content/docs/applications/dashy.mdx
+++ b/docs/src/content/docs/applications/dashy.mdx
@@ -26,6 +26,17 @@ By default, Dashy can be accessed at `http://[your_server_ip]:8082` or `https://
 See the default configuration options for Dashy at [`roles/dashy/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/dashy/defaults/main.yml).
 Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
 
+### Local icons
+
+Icons placed in `dashy_item_icons_directory` (by default `[docker_home]/dashy/item-icons`) are served by Dashy itself, for services with no icon in the built-in icon packs.
+Reference them in `conf.yml` by filename, or by `subfolder/name.svg` if you organize them into subdirectories:
+
+```yaml
+- title: Router
+  icon: router.svg
+  url: http://192.168.1.1
+```
+
 ## Alternatives
 
 - [Heimdall](../heimdall/)

--- a/roles/dashy/defaults/main.yml
+++ b/roles/dashy/defaults/main.yml
@@ -5,6 +5,9 @@ dashy_available_externally: false
 
 # directories
 dashy_data_directory: "{{ docker_home }}/dashy"
+# Icons placed here are served by Dashy itself, and referenced in conf.yml by bare filename
+# (`icon: router.svg`) or `subfolder/name.svg`, instead of a URL to an external icon service.
+dashy_item_icons_directory: "{{ dashy_data_directory }}/item-icons"
 
 # network
 dashy_hostname: dashy

--- a/roles/dashy/tasks/main.yml
+++ b/roles/dashy/tasks/main.yml
@@ -14,6 +14,7 @@
         state: directory
       with_items:
         - "{{ dashy_data_directory }}"
+        - "{{ dashy_item_icons_directory }}"
 
     - name: Copy base config
       ansible.builtin.copy:
@@ -32,6 +33,8 @@
         memory: "{{ dashy_memory }}"
         volumes:
           - "{{ dashy_data_directory }}/conf.yml:/app/user-data/conf.yml:rw"
+          # Container path is fixed: Dashy resolves local icons to the URL /item-icons/<file>.
+          - "{{ dashy_item_icons_directory }}:/app/user-data/item-icons:ro"
         labels:
           traefik.enable: "{{ (dashy_dns_accessible or dashy_available_externally) | string }}"
           traefik.http.services.dashy.loadbalancer.server.port: "8080"


### PR DESCRIPTION
Dashy has a built-in local icon feature: icons in its `user-data/item-icons` directory are referenced in `conf.yml` by bare filename (`icon: router.svg`) or `subfolder/name.svg`. The role couldn't reach it, since only `conf.yml` was mounted, so any icon placed in the container was lost on the next recreate.

Adds `dashy_item_icons_directory`, creates it, and mounts it read-only at `/app/user-data/item-icons`. Defaults to an empty directory under the existing data directory, so nothing changes for anyone not using it.

The container path is fixed, because Dashy resolves local icons to the URL `/item-icons/<file>`. Only the host path is configurable.

Tested on my host: an SVG dropped in the directory serves at `/item-icons/<file>` with the correct content type, and a tile referencing it by bare filename renders.
