### PR TITLE
feat(ts3web): add TS3Web role

### DIFF
--- a/docs/src/content/docs/applications/ts3web.mdx
+++ b/docs/src/content/docs/applications/ts3web.mdx
@@ -1,0 +1,72 @@
+---
+title: TS3Web
+tags: ["Voice Chat", "Monitoring"]
+---
+
+import Tags from "../../../components/Tags.astro"
+import RecentChanges from "../../../components/RecentChanges.astro"
+
+[Homepage](https://github.com/felbinger/TS3Web) |
+[Repository](https://github.com/felbinger/TS3Web)
+
+<Tags tags={frontmatter.tags} />
+
+TS3Web is a read-only web view of a [TeamSpeak 3](../teamspeak3/) server: who is connected, which channels they are in, and who is talking. It reads the server over its ServerQuery interface and renders a channel tree, so anyone on your network can see who is around without opening a TeamSpeak client.
+
+## Setting up
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+ts3web_enabled: true
+```
+
+Everything else has a working default when the [TeamSpeak 3](../teamspeak3/) role runs on the same host.
+
+By default, TS3Web can be accessed at `http://[your_server_ip]:8105` or `https://ts3web.[your_domain].com` if you have [DNS access](../../guides/dns-access/) configured.
+
+### The image is built locally
+
+Upstream publishes no image and the repository was archived in 2020, so this role clones the source onto the Docker host and builds it there. The first run therefore takes noticeably longer than a role that pulls a published image.
+
+`ts3web_image_version` doubles as the git ref to build from, so the running image stays reproducible and pinned. The clone is recursive because the PHP application lives in the `webinterface` submodule; without it the image builds with an empty web root.
+
+## Configuration
+
+See the default configuration options for TS3Web at [`roles/ts3web/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/ts3web/defaults/main.yml).
+Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
+
+`ts3web_ts_host` defaults to the Docker host's LAN address rather than a container name, because the TeamSpeak container publishes ServerQuery on the host and shares no user-defined network with this one. Point it elsewhere to view a server on another machine.
+
+### Two pages
+
+| Path | What it is |
+|---|---|
+| `/tsviewpub.php` | upstream's viewer, rendered once per request |
+| `/viewer.html` | auto-refresh wrapper around it, templated by this role |
+
+`tsviewpub.php` has no refresh of its own, so talk indicators go stale as soon as the page loads. `viewer.html` embeds it in an iframe and reloads only the iframe every `ts3web_refresh_seconds`. Point dashboard links at `/viewer.html`.
+
+`ts3web_viewer_params` is passed straight through to `tsviewpub.php`. `skey=0` selects the server configured by the role; the rest sets the virtual server id, icon placement and colours.
+
+### ServerQuery flood limits
+
+TeamSpeak rate-limits ServerQuery per source address, and every refresh is a fresh query. If the viewer intermittently reports that the host "isn't a ts3 instance", the refresh rate is tripping that limit. Either raise `ts3web_refresh_seconds`, or exempt the source with [TeamSpeak 3's](../teamspeak3/) allow list. Connections arrive from the Docker bridge rather than the host's LAN address, so the exemption is the bridge subnet:
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+teamspeak3_ip_whitelist: "127.0.0.1,::1,172.17.0.0/16"
+```
+
+With the source exempted, `ts3web_refresh_seconds: 1` is fine. Note the limit applies per source address, not per viewer, so simultaneous viewers multiply the query rate.
+
+### Access
+
+With `ts3web_available_externally: false` (the default), the Traefik router sits behind the `blockExternal` middleware and the viewer is reachable on your local network only. It exposes a TeamSpeak server's member list without authentication, so consider that before changing it.
+
+{/* 
+
+## Breaking Changes
+
+*/}
+
+## Recent Changes
+
+<RecentChanges application="ts3web" />

--- a/playbook.yml
+++ b/playbook.yml
@@ -462,6 +462,10 @@
       tags: transmission
       when: transmission_enabled or (transmission_container_names | intersect(running_containers) | length > 0)
 
+    - role: ts3web
+      tags: ts3web
+      when: ts3web_enabled or (ts3web_container_names | intersect(running_containers) | length > 0)
+
     - role: ttrss
       tags: ttrss
       when: ttrss_enabled or (ttrss_container_names | intersect(running_containers) | length > 0)

--- a/roles/ts3web/defaults/main.yml
+++ b/roles/ts3web/defaults/main.yml
@@ -1,0 +1,50 @@
+---
+ts3web_enabled: false
+ts3web_dns_accessible: "{{ traefik_enable_dns_for_all }}"
+ts3web_available_externally: false
+
+# directories
+# The upstream image (felbinger/TS3Web, the Psychokiller ts3wi viewer) is NOT published to any
+# registry and the repo was archived in 2020, so the image is built locally from a pinned commit.
+# This is where that source is cloned and built from.
+ts3web_build_directory: "{{ docker_home }}/ts3web/build"
+# Host dir for the templated auto-refresh wrapper page (bind-mounted into the web root).
+ts3web_data_directory: "{{ docker_home }}/ts3web/data"
+
+# TeamSpeak 3 ServerQuery connection that the viewer reads from.
+# Defaults to the Docker host's LAN IP + the teamspeak3 role's published ServerQuery port: the
+# teamspeak3 container publishes 10011 on the host and shares no user-defined network with us,
+# so reaching it via the host IP is the reliable path.
+ts3web_ts_host: "{{ ansible_default_ipv4.address }}"
+ts3web_ts_query_port: "{{ teamspeak3_serverquery_port | default(10011) }}"
+
+# Viewer display
+ts3web_alias: "TeamSpeak 3"
+ts3web_lang: en  # de, en, or nl
+
+# viewer
+# Point dashboard links at the auto-refresh wrapper page:
+#   https://{{ ts3web_hostname }}.{{ dns_domain }}/viewer.html
+# It embeds tsviewpub.php (read anonymously; skey=0 selects this env-configured server) and
+# reloads it every ts3web_refresh_seconds. Keep >=3s to stay under TS3 ServerQuery flood limits;
+# raise it if you see intermittent "host isn't a ts3 instance" errors (or whitelist the IP in TS3).
+# Note: the flood rate is per-source not per-viewer, so many simultaneous viewers multiply it.
+ts3web_refresh_seconds: 3
+ts3web_viewer_params: "skey=0&sid=1&showicons=right&bgcolor=ffffff&fontcolor=000000"
+
+# network
+ts3web_hostname: ts3web
+ts3web_port: 8105
+
+# containers
+ts3web_container_name: ts3web
+# No registry image exists; built locally (see tasks). ts3web_image_version doubles as the git
+# ref to build from, so the running image is reproducible and pinned against an archived upstream.
+ts3web_image_name: ts3web
+ts3web_image_version: dd21eea11c2229abfda573580f605014107f9e4f
+
+ts3web_container_names: # Used to check if app is running
+  - "{{ ts3web_container_name }}"
+
+# specs
+ts3web_memory: 256m

--- a/roles/ts3web/tasks/main.yml
+++ b/roles/ts3web/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+- name: Start TS3Web
+  when: ts3web_enabled
+  block:
+    - name: Check for TS3Web Breaking Changes
+      ansible.builtin.include_role:
+        name: breaking_changes
+      vars:
+        breaking_changes_application: ts3web
+
+    - name: Create TS3Web Directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ ts3web_build_directory }}"
+        - "{{ ts3web_data_directory }}"
+
+    # The upstream image is not published anywhere, so build it locally. Pinning the git ref to
+    # ts3web_image_version keeps the build reproducible against the archived upstream repo.
+    # recursive (the default) is REQUIRED: the actual PHP app lives in the `webinterface`
+    # git submodule (MEschenbacher/ts3web). Without it the image builds with an empty web root.
+    - name: Clone TS3Web Source
+      ansible.builtin.git:
+        repo: https://github.com/felbinger/TS3Web.git
+        dest: "{{ ts3web_build_directory }}"
+        version: "{{ ts3web_image_version }}"
+        recursive: true
+      register: ts3web_source
+
+    - name: Build TS3Web Image
+      community.docker.docker_image:
+        name: "{{ ts3web_image_name }}"
+        tag: "{{ ts3web_image_version }}"
+        source: build
+        build:
+          path: "{{ ts3web_build_directory }}"
+          pull: true
+        force_source: "{{ ts3web_source.changed }}"
+        state: present
+
+    # Auto-refresh wrapper (tsviewpub.php has no refresh of its own). Bind-mounted into the
+    # web root below. template replaces the file via atomic rename (new inode), but a single-file
+    # bind mount keeps pointing at the old inode until the container is recreated -- so recreate
+    # the container below when this changes.
+    # (Note the reverse is not handled: docker_container compares volumes as allow_more_present,
+    # so *removing* a mount still reports ok and needs a manual `docker rm -f` to take effect.)
+    - name: Template TS3Web Auto-refresh Viewer Page
+      ansible.builtin.template:
+        src: viewer.html.j2
+        dest: "{{ ts3web_data_directory }}/viewer.html"
+        mode: "0644"
+      register: ts3web_viewer
+
+    - name: TS3Web Docker Container
+      community.docker.docker_container:
+        name: "{{ ts3web_container_name }}"
+        image: "{{ ts3web_image_name }}:{{ ts3web_image_version }}"
+        pull: false
+        recreate: "{{ ts3web_viewer.changed }}"
+        volumes:
+          - "{{ ts3web_data_directory }}/viewer.html:/var/www/html/viewer.html:ro"
+        env:
+          HOST: "{{ ts3web_ts_host }}"
+          PORT: "{{ ts3web_ts_query_port | string }}"
+          ALIAS: "{{ ts3web_alias }}"
+          LANG: "{{ ts3web_lang }}"
+        ports:
+          - "{{ ts3web_port }}:80"
+        restart_policy: unless-stopped
+        memory: "{{ ts3web_memory }}"
+        labels:
+          traefik.enable: "{{ (ts3web_dns_accessible or ts3web_available_externally) | string }}"
+          traefik.http.services.ts3web.loadbalancer.server.port: "80"
+          traefik.http.routers.ts3web.rule: "Host(`{{ ts3web_hostname }}.{{ dns_domain }}`)"
+          traefik.http.routers.ts3web.tls.domains[0].main: "{{ dns_domain }}"
+          traefik.http.routers.ts3web.tls.domains[0].sans: "*.{{ dns_domain }}"
+          traefik.http.routers.ts3web.tls.certresolver: "letsencrypt"
+          traefik.http.routers.ts3web.middlewares: "{{ omit if ts3web_available_externally else 'blockExternal@file' }}"
+
+- name: Stop TS3Web
+  when: not ts3web_enabled
+  block:
+    - name: Stop TS3Web
+      community.docker.docker_container:
+        name: "{{ ts3web_container_name }}"
+        state: absent

--- a/roles/ts3web/templates/viewer.html.j2
+++ b/roles/ts3web/templates/viewer.html.j2
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+{# Auto-refresh wrapper for the read-only ts3web viewer. Reloads the embedded tsviewpub.php #}
+{# every ts3web_refresh_seconds so talk indicators update, while keeping the query rate low #}
+{# enough to avoid TS3 ServerQuery flood bans. Point dashboard links at this page. #}
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{ ts3web_alias }} viewer</title>
+  <style>
+    html, body { margin: 0; height: 100%; background: #ffffff; }
+    iframe { border: 0; width: 100%; height: 100%; display: block; }
+  </style>
+</head>
+<body>
+  <iframe id="ts3" src="tsviewpub.php?{{ ts3web_viewer_params }}"></iframe>
+  <script>
+    // Reload only the iframe (same-origin) so the outer page stays put.
+    setInterval(function () {
+      document.getElementById('ts3').contentWindow.location.reload();
+    }, {{ ts3web_refresh_seconds }} * 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Adds a `ts3web` role for [TS3Web](https://github.com/felbinger/TS3Web), a read-only web view of a TeamSpeak 3 server: who is connected, which channels they are in, and who is talking. Pairs with the existing `teamspeak3` role. I have been running it on my homelab for a while.

Upstream publishes no image and archived the repository in 2020, so the role clones the source onto the Docker host and builds it there, pinned to a commit through `ts3web_image_version`. That makes it the only role here that builds rather than pulls, and the first run is slower than a pull.

The rest is covered by the docs page in this PR and the task comments: the `viewer.html` refresh wrapper and why it forces a recreate, the ServerQuery flood-limit exemption, and why `ts3web_ts_host` defaults to the host's LAN address.

`tests/test.py` and `ansible-lint` both pass.
