### PR TITLE
fix(loki): persist log storage across container recreates

### DIFF
--- a/docs/src/content/docs/applications/loki.mdx
+++ b/docs/src/content/docs/applications/loki.mdx
@@ -32,6 +32,12 @@ By default, Loki can be accessed at `http://[your_server_ip]:3100/metrics` or `h
 See the default configuration options for Loki at [`roles/loki/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/loki/defaults/main.yml).
 Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
 
+Logs are stored on the host in `loki_storage_directory` (default `{{ docker_home }}/loki/data`), so they survive container recreates and image updates. How long they are kept is set by `loki_log_retention` (default `672h`, 28 days).
+
+<Aside type="caution">
+	Loki writes to that directory as `loki_user_id`:`loki_group_id` (default `1000`:`1000`). These need to match the user Ansible connects to your homelab as, otherwise the container can't write to the directory and will fail to start.
+</Aside>
+
 {/* 
 
 ## Breaking Changes

--- a/roles/loki/defaults/main.yml
+++ b/roles/loki/defaults/main.yml
@@ -5,12 +5,17 @@ loki_available_externally: false
 
 # directories
 loki_data_directory: "{{ docker_home }}/loki"
+loki_storage_directory: "{{ loki_data_directory }}/data"
 
 # network
 loki_hostname: loki
 loki_http_port: 3100
 loki_memberlist_port: 7946
 loki_grpc_port: 9095
+
+# uid/gid
+loki_user_id: "1000"
+loki_group_id: "1000"
 
 # containers
 loki_container_name: loki

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -19,6 +19,7 @@
         state: directory
       with_items:
         - "{{ loki_data_directory }}"
+        - "{{ loki_storage_directory }}"
 
     - name: Template Loki config
       ansible.builtin.template:
@@ -31,6 +32,7 @@
         name: "{{ loki_container_name }}"
         image: "{{ loki_image_name }}:{{ loki_image_version }}"
         pull: true
+        user: "{{ loki_user_id }}:{{ loki_group_id }}"
         command: ["-config.file=/etc/loki/config.yml"]
         ports:
           - "{{ loki_http_port }}:3100"
@@ -38,6 +40,7 @@
           - "{{ loki_grpc_port }}:9095"
         volumes:
           - "{{ loki_data_directory }}/config.yml:/etc/loki/config.yml"
+          - "{{ loki_storage_directory }}:/var/loki:rw"
         restart_policy: unless-stopped
         memory: "{{ loki_memory }}"
         restart: "{{ loki_config is changed }}"

--- a/roles/loki/templates/config.yml
+++ b/roles/loki/templates/config.yml
@@ -8,11 +8,11 @@ server:
 
 common:
   instance_addr: 127.0.0.1
-  path_prefix: /tmp/loki
+  path_prefix: /var/loki
   storage:
     filesystem:
-      chunks_directory: /tmp/loki/chunks
-      rules_directory: /tmp/loki/rules
+      chunks_directory: /var/loki/chunks
+      rules_directory: /var/loki/rules
   replication_factor: 1
   ring:
     kvstore:
@@ -58,6 +58,6 @@ frontend:
 
 
 compactor:
-  working_directory: /tmp/loki/retention
+  working_directory: /var/loki/retention
   delete_request_store: filesystem
   retention_enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Loki's `retention_period` is never reached because the log data is stored inside
the container. `config.yml` is the only bind mount, but `common.path_prefix` is
`/tmp/loki` — so chunks, the TSDB index, and the ingester WAL all live in the
container's writable layer. Every image update recreates the container and destroys
the entire log history.

On my install `loki_log_retention` is the default `672h` (28 days), but the oldest
queryable line was exactly the container's creation timestamp — 9 days, matching a
Watchtower update that pulled a new `grafana/loki:latest`. The image declares no
`VOLUME`, so there is no anonymous volume carrying the data across either. In
practice retention is "time since the image last published", not what's configured.

This bind-mounts a host directory and moves `path_prefix` to `/var/loki`, matching
the official Loki Helm chart (`commonConfig.path_prefix: /var/loki`). `/tmp/loki` is
the quickstart default that upstream flagged in grafana/loki#7748, since `/tmp` is
frequently tmpfs.

Setting `path_prefix` is what does the work: checking `/config` on a running
instance, 8 further storage paths are derived from it — the ingester WAL,
`tsdb_shipper` `active_index_directory` and `cache_location`, the ruler dirs, and
the shutdown marker. Mounting only the chunks directory would leave the index and
WAL ephemeral and still lose queryability on recreate.

It also sets `user:` with `loki_user_id`/`loki_group_id`, since the image runs as
uid 10001 and otherwise can't write to the mounted directory — same pattern as
`roles/alertmanager` and `roles/grafana`.

**Which issue (if any) this PR fixes**:

Fixes #23

**Any other useful info**:

- Not a breaking change: `loki_data_directory` keeps its current meaning and
  location. A new `loki_storage_directory` is added for the chunk/index data.
- One-time effect: the first deploy after this recreates the container, losing
  whatever logs are currently in it — the same loss that already happens on every
  image update, just once more.
- Optionally, that last loss can be avoided by copying the existing data out first:

  ```bash
  docker stop loki                                  # flush cleanly; a live copy
                                                    # gives you a torn WAL
  mkdir -p <loki_storage_directory>
  docker cp loki:/tmp/loki/. <loki_storage_directory>/
  rm -rf <loki_storage_directory>/wal              # see note below
  # then deploy
  ```

  `docker cp` extracts client-side as the user running it, so the files land owned by
  that user — no chown needed as long as that's the same user Ansible connects as
  (which is also the uid the container will run as). Only if you ran it under `sudo`
  do you need to chown back.

  Dropping `wal/` is deliberate: `docker stop` flushes in-memory chunks to disk, so
  the WAL has nothing left to contribute, and copying it imports a partially-written
  tail segment. I verified this on my own migration — Loki logged "Recovered from WAL
  segments with errors" on every start until that segment aged out. Harmless (it
  recovered 14k entries around it and self-cleared once the next checkpoint truncated
  the segment), but there's no reason to import it.

- Storage is modest: ~5.5MB/day observed, so a full 28-day window is ~150MB.
- Verified on Ubuntu 24.04 (ZFS): container survives `docker rm -f` + redeploy with
  the oldest queryable line unchanged; a log line ingested 8s before an ungraceful
  kill was recovered from the WAL on restart; the container's writable layer went
  from 51.8MB to 0B, confirming nothing is being written inside it anymore.
