### PR TITLE
feat(umtk): Add UMTK (Upcoming Movies & TV Shows for Kometa)

### DIFF
--- a/docs/src/content/docs/applications/umtk.mdx
+++ b/docs/src/content/docs/applications/umtk.mdx
@@ -1,0 +1,42 @@
+---
+title: UMTK
+tags: ["Movies", "TV"]
+---
+
+import Tags from "../../../components/Tags.astro"
+import RecentChanges from "../../../components/RecentChanges.astro"
+
+[Repository](https://github.com/netplexflix/Upcoming-Movies-TV-Shows-for-Kometa)
+
+<Tags tags={frontmatter.tags} />
+
+UMTK (Upcoming Movies & TV Shows for Kometa) checks Radarr and Sonarr for upcoming and trending movies and TV shows and creates .yml files which can be used by Kometa to create collections and overlays. It also bundles TSSK (TV Show Status for Kometa), which tracks the status of the shows already in your library.
+
+## Setting up
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+umtk_enabled: true
+```
+
+UMTK writes its .yml files into Kometa's config directory, so Kometa must be enabled and set up first. Point Kometa at the generated files by adding them to its `collection_files` and `overlay_files`, where they appear as `/config/umtk/`.
+
+By default, UMTK can be accessed at `http://[your_server_ip]:2120` or `https://umtk.[your_domain].com` if you have [DNS access](../../guides/dns-access/) configured. The web UI asks you to set a password the first time it is opened.
+
+## Configuration
+
+See the default configuration options for UMTK at [`roles/umtk/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/umtk/defaults/main.yml).
+Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
+
+UMTK's own settings (Radarr and Sonarr connections, which categories to process, overlay styling) live in `umtk/config/` in your `docker_home`, not in Ansible. The application rewrites those files itself when you save from the web UI, so the role creates the directory and leaves the contents alone. The same directory holds your Radarr and Sonarr API keys and the web UI password, so it is created with `0700` permissions.
+
+`CRON` in `umtk_environment_variables` only seeds the schedule on first launch. After that the web UI owns it, and changing the variable has no effect.
+
+{/* 
+
+## Breaking Changes
+
+*/}
+
+## Recent Changes
+
+<RecentChanges application="umtk" />

--- a/playbook.yml
+++ b/playbook.yml
@@ -470,6 +470,10 @@
       tags: ubooquity
       when: ubooquity_enabled or (ubooquity_container_names | intersect(running_containers) | length > 0)
 
+    - role: umtk
+      tags: umtk
+      when: umtk_enabled or (umtk_container_names | intersect(running_containers) | length > 0)
+
     - role: wallabag
       tags: wallabag
       when: wallabag_enabled or (wallabag_container_names | intersect(running_containers) | length > 0)

--- a/roles/umtk/defaults/main.yml
+++ b/roles/umtk/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+umtk_enabled: false
+umtk_dns_accessible: "{{ traefik_enable_dns_for_all }}"
+umtk_available_externally: false
+
+# directories
+umtk_data_directory: "{{ docker_home }}/umtk/"
+umtk_config_directory: "{{ docker_home }}/umtk/config/"
+# UMTK writes its Kometa YAML here. Kometa reads it as `/config/umtk/`
+umtk_output_directory: "{{ kometa_config_directory }}/umtk"
+
+# network
+umtk_hostname: umtk
+umtk_port: 2120
+
+# containers
+umtk_container_name: umtk
+umtk_image_name: netplexflix/umtk
+umtk_image_version: latest
+
+umtk_container_names: # Used to check if app is running
+  - "{{ umtk_container_name }}"
+
+# specs
+umtk_memory: 1g
+umtk_user_id: "1000"
+umtk_group_id: "1000"
+
+# config
+umtk_environment_variables:
+  # Seeds the schedule on first launch only. UMTK writes the schedule into its
+  # own config file and the web UI owns it from then on, so changing this later
+  # has no effect
+  CRON: "0 2 * * *"
+  DOCKER: "true" # important for path reference
+  PUID: "{{ umtk_user_id }}"
+  PGID: "{{ umtk_group_id }}"
+  TZ: "{{ computer_timezone }}"

--- a/roles/umtk/tasks/main.yml
+++ b/roles/umtk/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- name: Start UMTK
+  when: umtk_enabled
+  block:
+    - name: Check for UMTK Breaking Changes
+      ansible.builtin.include_role:
+        name: breaking_changes
+      vars:
+        breaking_changes_application: umtk
+
+    - name: Check for Kometa installation
+      ansible.builtin.fail:
+        msg: "UMTK requires Kometa enabled and running, please set that up first."
+      when: kometa_enabled is false
+
+    - name: Create UMTK Directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ umtk_data_directory }}"
+        - "{{ umtk_output_directory }}"
+
+    - name: Create UMTK Config Directory
+      ansible.builtin.file:
+        path: "{{ umtk_config_directory }}"
+        state: directory
+        mode: "0700"
+
+    - name: UMTK Docker Container
+      community.docker.docker_container:
+        name: "{{ umtk_container_name }}"
+        image: "{{ umtk_image_name }}:{{ umtk_image_version }}"
+        pull: true
+        volumes:
+          - "{{ umtk_config_directory }}:/app/config:rw"
+          - "{{ umtk_output_directory }}:/app/kometa:rw"
+        env: "{{ umtk_environment_variables }}"
+        ports:
+          - "{{ umtk_port }}:2120"
+        restart_policy: unless-stopped
+        memory: "{{ umtk_memory }}"
+        labels:
+          traefik.enable: "{{ (umtk_dns_accessible or umtk_available_externally) | string }}"
+          traefik.http.services.umtk.loadbalancer.server.port: "2120"
+          traefik.http.routers.umtk.rule: "Host(`{{ umtk_hostname ~ '.' if umtk_hostname else ''}}{{ dns_domain }}`)"
+          traefik.http.routers.umtk.tls.domains[0].main: "{{ dns_domain }}"
+          traefik.http.routers.umtk.tls.domains[0].sans: "*.{{ dns_domain }}"
+          traefik.http.routers.umtk.tls.certresolver: "letsencrypt"
+          traefik.http.routers.umtk.middlewares: "{{ omit if umtk_available_externally else 'blockExternal@file' }}"
+
+- name: Stop UMTK
+  when: not umtk_enabled
+  block:
+    - name: Stop UMTK
+      community.docker.docker_container:
+        name: "{{ umtk_container_name }}"
+        state: absent


### PR DESCRIPTION
Adds the **UMTK** (Upcoming Movies & TV Shows for Kometa) application. UMTK reads Radarr and Sonarr for upcoming and trending movies and shows and writes `.yml` files that Kometa consumes to build collections and overlays, so it complements the existing `kometa` role.

This follows up on #9, which added TSSK. You asked for UMTK instead, since the same author has archived TSSK in favour of it. UMTK bundles TSSK as a module, gated behind `enable_tssk` in its own config, so an existing TSSK setup carries over.

Built with the standard role layout (defaults + tasks), a docs page, and a `playbook.yml` entry. Two things are worth calling out:

- The role templates no config. UMTK owns its config files: it rewrites them from its web UI and persists the schedule into them, so anything Ansible wrote would be clobbered and report changed forever. The role creates the directories and the container only. `CRON` is a first-launch seed for that reason.
- The config directory is created `0700`. It holds the Radarr and Sonarr API keys and the web UI password hash, and the file itself cannot keep a mode because the app replaces it atomically. The container entrypoint chowns `/app` to PUID/PGID before dropping privileges, so `0700` is still usable by the app user.

## Testing
- `python tests/test.py` passes (no port/hostname conflicts).
- `ansible-lint` passes.

I am cutting my own TSSK install over to this role next and will report back if the deploy turns up anything.