### PR TITLE
feat(plex_consent_remover): add Plex Consent Remover role

### DIFF
--- a/docs/src/content/docs/applications/plex_consent_remover.mdx
+++ b/docs/src/content/docs/applications/plex_consent_remover.mdx
@@ -1,0 +1,95 @@
+---
+title: Plex Consent Remover
+tags: ["Media Server", "Privacy"]
+---
+
+import { Aside } from "@astrojs/starlight/components"
+import Tags from "../../../components/Tags.astro"
+import RecentChanges from "../../../components/RecentChanges.astro"
+
+[Repository](https://github.com/cyberbrix/plexconsentremover)
+
+<Tags tags={frontmatter.tags} />
+
+Periodically revokes the consent Plex holds to share your account data with advertising vendors.
+
+Plex keeps a per-account consent list, one entry per advertising vendor. Turning those off in the
+Plex UI is not permanent: new vendors can arrive with consent already granted, so a one-time opt-out
+drifts back open. This checks the list on an interval and switches any granted entry back off.
+
+## Setting up
+
+```yaml title="inventories/homelab/group_vars/homelab.yml"
+plex_consent_remover_enabled: true
+
+# You will need to provide a Plex token
+plex_consent_remover_plex_token: ""
+
+# Optionally change how often consent is checked, in seconds (default: daily)
+plex_consent_remover_interval: 86400
+```
+
+### Getting a token
+
+Any Plex account token works, and [Finding an authentication
+token](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/)
+describes the quickest way to get one.
+
+Copying a token out of Plex Web ties this to that browser session, so signing out of the browser can
+take it down with it. To give it a token of its own, use the PIN flow instead: `POST` to
+`https://plex.tv/api/v2/pins` with your own `X-Plex-Client-Identifier` and an
+`X-Plex-Product` of your choosing, enter the returned four character code at
+[plex.tv/link](https://plex.tv/link), then read `authToken` back from the pin. It appears under
+plex.tv → Authorized Devices as its own row, revocable without disturbing your Plex server or any
+signed-in client.
+
+## Usage
+
+There is nothing to interact with. The container checks on the interval and does nothing when there
+is no consent to revoke, so empty output from `docker logs plex_consent_remover` is the normal,
+healthy state. When it does act, it logs how many vendors it found and whether the update went
+through.
+
+To check immediately instead of waiting for the interval:
+
+```sh
+docker exec plex_consent_remover sh /app/plexconsent.sh
+```
+
+<Aside type="caution">
+	That is the real code path, not a dry run: it revokes consent if any is granted.
+  It exits `0` if Plex was reachable and the token was accepted, `1` if it could not read or write
+  the consent list.
+</Aside>
+
+## How this differs from the original script
+
+[The original](https://github.com/cyberbrix/plexconsentremover) is a bash script meant for cron on a
+host with `jq` installed, with the Plex token pasted into the file. The API calls and the approach
+are its work.
+
+This role ships a rewrite of that logic instead of a copy of the script, so that it can run the way
+everything else here does: in a container, taking its token from the environment rather than from
+inside the file, in POSIX `sh` so a plain Alpine image with `curl` and `jq` is enough. It logs a
+count of consenting vendors where the original names each one, which saves a second API call for a
+log line.
+
+It does not track the original project. If Plex changes the consent API, the script in
+[`roles/plex_consent_remover/files/plexconsent.sh`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/plex_consent_remover/files/plexconsent.sh)
+needs the change made by hand. `tests/plex_consent_remover.sh` exercises it against a stubbed Plex
+API and needs no network.
+
+## Configuration
+
+See the default configuration options for Plex Consent Remover at [`roles/plex_consent_remover/defaults/main.yml`](https://github.com/Dylancyclone/ansible-homelab-orchestration/blob/main/roles/plex_consent_remover/defaults/main.yml).
+Add any overrides to your `inventories/[your_inventory]/group_vars/homelab.yml` file.
+
+{/* 
+
+## Breaking Changes
+
+*/}
+
+## Recent Changes
+
+<RecentChanges application="plex_consent_remover" />

--- a/playbook.yml
+++ b/playbook.yml
@@ -334,6 +334,10 @@
       tags: plex
       when: plex_enabled or (plex_container_names | intersect(running_containers) | length > 0)
 
+    - role: plex_consent_remover
+      tags: plex_consent_remover
+      when: plex_consent_remover_enabled or (plex_consent_remover_container_names | intersect(running_containers) | length > 0)
+
     - role: portainer
       tags: portainer
       when: portainer_enabled or (portainer_container_names | intersect(running_containers) | length > 0)

--- a/roles/plex_consent_remover/defaults/main.yml
+++ b/roles/plex_consent_remover/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+plex_consent_remover_enabled: false
+
+# Plex token: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
+plex_consent_remover_plex_token: ""
+# How often to check for granted consent, in seconds
+plex_consent_remover_interval: 86400
+
+# directories
+plex_consent_remover_data_directory: "{{ docker_home }}/plex_consent_remover"
+
+# containers
+plex_consent_remover_container_name: plex_consent_remover
+plex_consent_remover_image_name: alpine
+plex_consent_remover_image_version: "3"
+
+plex_consent_remover_container_names: # Used to check if app is running
+  - "{{ plex_consent_remover_container_name }}"
+
+# specs
+plex_consent_remover_memory: 128m

--- a/roles/plex_consent_remover/files/plexconsent.sh
+++ b/roles/plex_consent_remover/files/plexconsent.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Revokes consent for Plex to share your data with advertising vendors.
+#
+# The API calls come from https://github.com/cyberbrix/plexconsentremover, rewritten to run in a
+# container: POSIX sh so a plain Alpine image suffices, token from the environment so the file holds
+# no secret, and a single pass so the caller controls the schedule. Upstream changes are not tracked.
+
+TOKEN="${PLEX_TOKEN:-}"
+CONSENT_URL="${CONSENT_URL:-https://plex.tv/api/v2/user/consent}"
+
+if [ -z "$TOKEN" ]; then
+  echo "PLEX_TOKEN is not set"
+  exit 1
+fi
+
+command -v jq >/dev/null 2>&1 || apk add --no-cache curl jq >/dev/null
+
+if ! consent=$(curl -sf -H "X-Plex-Token: $TOKEN" -H "Accept: application/json" "$CONSENT_URL") ||
+  ! printf '%s' "$consent" | jq -e 'has("vendorListVersion")' >/dev/null 2>&1; then
+  echo "Could not read consent from Plex.tv"
+  exit 1
+fi
+
+printf '%s' "$consent" | jq -e '[.vendors[].consent] | any' >/dev/null || exit 0
+
+granted=$(printf '%s' "$consent" | jq '[.vendors[] | select(.consent)] | length')
+echo "$granted vendor(s) have consent to gather your info from Plex. Removing consent."
+
+if printf '%s' "$consent" | jq '.language = "en" | .vendors[].consent = false' |
+  curl -sf -X PUT -H "X-Plex-Token: $TOKEN" -H "Accept: application/json" \
+    -H "Content-Type: application/json" --data @- "$CONSENT_URL" >/dev/null; then
+  echo "Updated consent status"
+else
+  echo "Error updating consent on Plex.tv"
+  exit 1
+fi

--- a/roles/plex_consent_remover/tasks/main.yml
+++ b/roles/plex_consent_remover/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: Start Plex Consent Remover
+  when: plex_consent_remover_enabled
+  block:
+    - name: Check for Plex Consent Remover Breaking Changes
+      ansible.builtin.include_role:
+        name: breaking_changes
+      vars:
+        breaking_changes_application: plex_consent_remover
+
+    - name: Create Plex Consent Remover Directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ plex_consent_remover_data_directory }}"
+
+    - name: Copy Plex Consent Remover Script
+      ansible.builtin.copy:
+        src: plexconsent.sh
+        dest: "{{ plex_consent_remover_data_directory }}/plexconsent.sh"
+        mode: "0755"
+      register: plex_consent_remover_script
+
+    - name: Plex Consent Remover Docker Container
+      community.docker.docker_container:
+        name: "{{ plex_consent_remover_container_name }}"
+        image: "{{ plex_consent_remover_image_name }}:{{ plex_consent_remover_image_version }}"
+        pull: true
+        command: ["/bin/sh", "-c", "while true; do /app/plexconsent.sh; sleep $INTERVAL; done"]
+        volumes:
+          - "{{ plex_consent_remover_data_directory }}:/app:ro"
+        env:
+          PLEX_TOKEN: "{{ plex_consent_remover_plex_token }}"
+          INTERVAL: "{{ plex_consent_remover_interval | string }}"
+        restart_policy: unless-stopped
+        restart: "{{ plex_consent_remover_script is changed }}"
+        memory: "{{ plex_consent_remover_memory }}"
+      no_log: true
+
+- name: Stop Plex Consent Remover
+  when: not plex_consent_remover_enabled
+  block:
+    - name: Stop Plex Consent Remover
+      community.docker.docker_container:
+        name: "{{ plex_consent_remover_container_name }}"
+        state: absent

--- a/tests/plex_consent_remover.sh
+++ b/tests/plex_consent_remover.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Checks roles/plex_consent_remover/files/plexconsent.sh against a stubbed Plex API.
+#
+# Usage: sh tests/plex_consent_remover.sh
+
+set -eu
+
+script="$(cd "$(dirname "$0")/.." && pwd)/roles/plex_consent_remover/files/plexconsent.sh"
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+# Stub curl: a PUT saves its body to $PUT_FILE, anything else returns $GET_FILE
+cat >"$dir/curl" <<'EOF'
+#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "PUT" ]; then
+    cat >"$PUT_FILE"
+    exit "${PUT_RC:-0}"
+  fi
+done
+cat "$GET_FILE"
+exit "${GET_RC:-0}"
+EOF
+chmod +x "$dir/curl"
+
+export PATH="$dir:$PATH"
+export GET_FILE="$dir/get.json" PUT_FILE="$dir/put.json"
+export GET_RC=0 PUT_RC=0
+export CONSENT_URL="https://plex.example/consent"
+export PLEX_TOKEN="test-token"
+
+granted='{"vendorListVersion":1,"language":null,"vendors":[{"id":1,"consent":true},{"id":2,"consent":false},{"id":3,"consent":true}]}'
+none='{"vendorListVersion":1,"language":"en","vendors":[{"id":1,"consent":false},{"id":2,"consent":false}]}'
+
+fail() {
+  echo "FAIL: $1"
+  exit 1
+}
+
+run() { # run <expected_rc>; stdout captured in $out
+  rm -f "$PUT_FILE"
+  set +e
+  out=$(sh "$script" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" = "$1" ] || fail "$2 (expected rc $1, got $rc: $out)"
+}
+
+# Consent granted: every vendor is turned off and the language is set
+printf '%s' "$granted" >"$GET_FILE"
+run 0 "granted consent"
+echo "$out" | grep -q "^2 vendor(s) have consent" || fail "granted consent count not reported: $out"
+echo "$out" | grep -q "Updated consent status" || fail "granted consent not confirmed: $out"
+[ -f "$PUT_FILE" ] || fail "granted consent did not PUT"
+jq -e '[.vendors[].consent] | any | not' "$PUT_FILE" >/dev/null || fail "PUT body still grants consent"
+jq -e '.language == "en"' "$PUT_FILE" >/dev/null || fail "PUT body did not set language"
+jq -e '(.vendors | length) == 3' "$PUT_FILE" >/dev/null || fail "PUT body dropped vendors"
+
+# Nothing granted: no write at all
+printf '%s' "$none" >"$GET_FILE"
+run 0 "no consent granted"
+[ ! -f "$PUT_FILE" ] || fail "PUT sent when no consent was granted"
+[ -z "$out" ] || fail "unexpected output when no consent was granted: $out"
+
+# Unexpected response body
+printf '%s' '{"error":"nope"}' >"$GET_FILE"
+run 1 "unexpected response body"
+echo "$out" | grep -q "Could not read consent" || fail "bad body not reported: $out"
+
+# Not JSON at all
+printf '%s' '<html>go away</html>' >"$GET_FILE"
+run 1 "non-json response"
+echo "$out" | grep -q "Could not read consent" || fail "non-json not reported: $out"
+
+# Failed GET
+printf '%s' "$granted" >"$GET_FILE"
+GET_RC=22
+run 1 "failed GET"
+echo "$out" | grep -q "Could not read consent" || fail "failed GET not reported: $out"
+GET_RC=0
+
+# Failed PUT
+PUT_RC=22
+run 1 "failed PUT"
+echo "$out" | grep -q "Error updating consent" || fail "failed PUT not reported: $out"
+PUT_RC=0
+
+# Missing token
+PLEX_TOKEN=""
+run 1 "missing token"
+echo "$out" | grep -q "PLEX_TOKEN is not set" || fail "missing token not reported: $out"
+
+echo "PASS"


### PR DESCRIPTION
Adds a `plex_consent_remover` role: a container that revokes the consent Plex holds to share account
data with advertising vendors. Plex can add new vendors already consented, so opting out once in the
UI does not hold. It re-checks daily, turns any granted entry back off, and stays silent otherwise.
Disabled by default, no ports, no hostname.

Two deviations from how roles here usually look, both your call:

- **It ships a script rather than pointing at an image.** No published image exists, so the role
  copies 25 lines of `sh` to the data directory and runs it in `alpine:3` with `curl` and `jq`
  installed on start.
- **It has a test script, which no other role does.** Offline, stubs `curl`, covers the revoke path
  and six failure paths. Not wired into `tests/test.py`. Easy to drop.

Approach and API calls come from [cyberbrix/plexconsentremover](https://github.com/cyberbrix/plexconsentremover),
reimplemented rather than copied (POSIX `sh`, token from the environment, no licence file on that
repo). Credited on the docs page.

`tests/test.py` and `ansible-lint playbook.yml` both pass. Deployed and verified against a live Plex
account: one vendor granted, container run, vendor back off.

Generated with [Claude Code](https://claude.com/claude-code)
