### PR TITLE
fix(stirlingpdf): Fix startup crash loop and login not being disabled

### DIFF
--- a/roles/stirlingpdf/defaults/main.yml
+++ b/roles/stirlingpdf/defaults/main.yml
@@ -19,4 +19,6 @@ stirlingpdf_container_names: # Used to check if app is running
   - "{{ stirlingpdf_container_name }}"
 
 # specs
-stirlingpdf_memory: 1g
+# The image derives JVM heap and metaspace sizing from the container limit.
+# Below 1025MB it caps metaspace at 128m, which the app exhausts during startup.
+stirlingpdf_memory: 4g

--- a/roles/stirlingpdf/tasks/main.yml
+++ b/roles/stirlingpdf/tasks/main.yml
@@ -25,7 +25,7 @@
         volumes:
           - "{{ stirlingpdf_data_directory }}:/configs:rw"
         env:
-          DOCKER_ENABLE_SECURITY: "false"
+          SECURITY_ENABLELOGIN: "false"
         restart_policy: unless-stopped
         memory: "{{ stirlingpdf_memory }}"
         labels:


### PR DESCRIPTION
Stirling PDF 2.x doesn't come up with the role's current defaults. Two fixes.

**Memory 1g → 4g.** The image sizes the JVM from the container limit. 1g lands in its <=1024MB tier, which caps metaspace at 128m, and Spring Boot 4 dies during startup:

```
java.lang.OutOfMemoryError: Metaspace
Terminating due to java.lang.OutOfMemoryError: Metaspace
```

The container then restart-loops. The <=4096MB tier gives 256m and it starts in ~25s.

**`DOCKER_ENABLE_SECURITY` → `SECURITY_ENABLELOGIN`.** In 2.x the old var only gates the security jar download, so login stays on and the app serves 401 at `/`. Verified on 2.14.3: with `DOCKER_ENABLE_SECURITY=false` the container 401s and `settings.yml` keeps `enableLogin: true`; with `SECURITY_ENABLELOGIN=false` the same image returns 200. Same intent as the current line, no new variables.

Tested against 2.14.3 on Docker 28.5.1. `python tests/test.py` reports 0 failures and `ansible-lint playbook.yml` passes with 0 failures and 0 warnings.

Generated with [Claude Code](https://claude.com/claude-code)
